### PR TITLE
Backend reliability: indexes, transactions, N+1 fix, session cleanup

### DIFF
--- a/backend/migrations/002_indexes.sql
+++ b/backend/migrations/002_indexes.sql
@@ -1,0 +1,12 @@
+-- Performance indexes for common queries
+CREATE INDEX IF NOT EXISTS idx_sessions_token ON sessions(token);
+CREATE INDEX IF NOT EXISTS idx_sessions_expiry ON sessions(expires_at);
+CREATE INDEX IF NOT EXISTS idx_schedule_blocks_user_day ON schedule_blocks(user_id, day_of_week);
+CREATE INDEX IF NOT EXISTS idx_progressions_user ON progressions(user_id);
+CREATE INDEX IF NOT EXISTS idx_progression_phases_prog ON progression_phases(progression_id);
+CREATE INDEX IF NOT EXISTS idx_progress_logs_user_date ON progress_logs(user_id, date);
+CREATE INDEX IF NOT EXISTS idx_categories_user ON categories(user_id);
+CREATE INDEX IF NOT EXISTS idx_budget_items_user ON budget_items(user_id);
+CREATE INDEX IF NOT EXISTS idx_friendships_a ON friendships(user_a);
+CREATE INDEX IF NOT EXISTS idx_friendships_b ON friendships(user_b);
+CREATE INDEX IF NOT EXISTS idx_invite_links_code ON invite_links(code);

--- a/backend/src/db.rs
+++ b/backend/src/db.rs
@@ -26,16 +26,27 @@ pub async fn init_pool(db_path: &str) -> SqlitePool {
         .ok();
 
     // Run migrations
-    let migration_sql = include_str!("../migrations/001_init.sql");
-    for statement in migration_sql.split(';') {
-        let trimmed = statement.trim();
-        if !trimmed.is_empty() {
-            sqlx::query(trimmed)
-                .execute(&pool)
-                .await
-                .expect("Failed to run migration");
+    let migrations: &[&str] = &[
+        include_str!("../migrations/001_init.sql"),
+        include_str!("../migrations/002_indexes.sql"),
+    ];
+    for migration_sql in migrations {
+        for statement in migration_sql.split(';') {
+            let trimmed = statement.trim();
+            if !trimmed.is_empty() {
+                sqlx::query(trimmed)
+                    .execute(&pool)
+                    .await
+                    .expect("Failed to run migration");
+            }
         }
     }
+
+    // Clean up expired sessions on startup
+    sqlx::query("DELETE FROM sessions WHERE expires_at < datetime('now')")
+        .execute(&pool)
+        .await
+        .ok();
 
     tracing::info!("Database initialized at {}", db_path);
     pool

--- a/backend/src/routes/budget.rs
+++ b/backend/src/routes/budget.rs
@@ -24,9 +24,12 @@ pub async fn set_budget(
     AuthUser(user_id): AuthUser,
     Json(items): Json<Vec<BudgetItemInput>>,
 ) -> Result<Json<Vec<BudgetItem>>, (StatusCode, String)> {
+    let mut tx = pool.begin().await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
     sqlx::query("DELETE FROM budget_items WHERE user_id = ?")
         .bind(user_id)
-        .execute(&pool)
+        .execute(&mut *tx)
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
@@ -39,10 +42,13 @@ pub async fn set_budget(
         .bind(item.hours)
         .bind(&item.color)
         .bind(item.sort_order.unwrap_or(i as i64))
-        .execute(&pool)
+        .execute(&mut *tx)
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
     }
+
+    tx.commit().await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
     let result = sqlx::query_as::<_, BudgetItem>(
         "SELECT * FROM budget_items WHERE user_id = ? ORDER BY sort_order"

--- a/backend/src/routes/leaderboard.rs
+++ b/backend/src/routes/leaderboard.rs
@@ -27,6 +27,10 @@ pub async fn get_leaderboard(
     }).collect();
     user_ids.push(user_id);
 
+    if user_ids.is_empty() {
+        return Ok(Json(Vec::new()));
+    }
+
     let (from_date, to_date) = match query.period.as_deref() {
         Some("month") => {
             let now = chrono::Local::now().date_naive();
@@ -41,66 +45,79 @@ pub async fn get_leaderboard(
         }
     };
 
-    let mut entries = Vec::new();
-    for uid in &user_ids {
-        let user = sqlx::query_as::<_, User>("SELECT * FROM users WHERE id = ?")
-            .bind(uid)
-            .fetch_one(&pool).await
-            .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+    // Batch fetch all users in one query
+    let placeholders: String = user_ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
 
-        let total: f64 = sqlx::query_scalar::<_, f64>(
-            "SELECT COALESCE(SUM(hours), 0.0) FROM progress_logs WHERE user_id = ? AND date >= ? AND date <= ?"
-        )
-        .bind(uid).bind(&from_date).bind(&to_date)
-        .fetch_one(&pool).await
-        .unwrap_or(0.0);
+    let users_query = format!("SELECT * FROM users WHERE id IN ({})", placeholders);
+    let mut q = sqlx::query_as::<_, User>(&users_query);
+    for id in &user_ids { q = q.bind(id); }
+    let users: Vec<User> = q.fetch_all(&pool).await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
-        let cat_rows: Vec<(String, f64)> = sqlx::query_as(
-            "SELECT category_name, SUM(hours) as total FROM progress_logs WHERE user_id = ? AND date >= ? AND date <= ? GROUP BY category_name ORDER BY total DESC"
-        )
-        .bind(uid).bind(&from_date).bind(&to_date)
-        .fetch_all(&pool).await
-        .unwrap_or_default();
+    // Batch fetch all progress totals in one query
+    let totals_query = format!(
+        "SELECT user_id, COALESCE(SUM(hours), 0.0) as total FROM progress_logs WHERE user_id IN ({}) AND date >= ? AND date <= ? GROUP BY user_id",
+        placeholders
+    );
+    let mut q = sqlx::query_as::<_, (i64, f64)>(&totals_query);
+    for id in &user_ids { q = q.bind(id); }
+    q = q.bind(&from_date).bind(&to_date);
+    let totals: Vec<(i64, f64)> = q.fetch_all(&pool).await.unwrap_or_default();
+    let totals_map: std::collections::HashMap<i64, f64> = totals.into_iter().collect();
 
-        let categories: Vec<CategoryHours> = cat_rows.into_iter().map(|(name, hours)| {
-            CategoryHours { category_name: name, hours }
-        }).collect();
+    // Batch fetch all category breakdowns in one query
+    let cats_query = format!(
+        "SELECT user_id, category_name, SUM(hours) as total FROM progress_logs WHERE user_id IN ({}) AND date >= ? AND date <= ? GROUP BY user_id, category_name ORDER BY total DESC",
+        placeholders
+    );
+    let mut q = sqlx::query_as::<_, (i64, String, f64)>(&cats_query);
+    for id in &user_ids { q = q.bind(id); }
+    q = q.bind(&from_date).bind(&to_date);
+    let cat_rows: Vec<(i64, String, f64)> = q.fetch_all(&pool).await.unwrap_or_default();
+    let mut cats_map: std::collections::HashMap<i64, Vec<CategoryHours>> = std::collections::HashMap::new();
+    for (uid, name, hours) in cat_rows {
+        cats_map.entry(uid).or_default().push(CategoryHours { category_name: name, hours });
+    }
 
-        let streak = calculate_streak(&pool, *uid).await;
+    // Batch fetch all streaks: get distinct dates for all users in one query
+    let dates_query = format!(
+        "SELECT user_id, date FROM progress_logs WHERE user_id IN ({}) GROUP BY user_id, date ORDER BY user_id, date DESC",
+        placeholders
+    );
+    let mut q = sqlx::query_as::<_, (i64, String)>(&dates_query);
+    for id in &user_ids { q = q.bind(id); }
+    let all_dates: Vec<(i64, String)> = q.fetch_all(&pool).await.unwrap_or_default();
+    let mut dates_map: std::collections::HashMap<i64, Vec<String>> = std::collections::HashMap::new();
+    for (uid, date) in all_dates {
+        dates_map.entry(uid).or_default().push(date);
+    }
 
-        entries.push(LeaderboardEntry {
-            user_id: *uid,
+    let today = chrono::Local::now().date_naive();
+
+    let mut entries: Vec<LeaderboardEntry> = users.into_iter().map(|user| {
+        let streak = calculate_streak_from_dates(dates_map.get(&user.id).map(|v| v.as_slice()).unwrap_or(&[]), today);
+        LeaderboardEntry {
+            user_id: user.id,
             username: user.username,
             display_name: user.display_name,
-            total_hours: total,
+            total_hours: *totals_map.get(&user.id).unwrap_or(&0.0),
             streak_days: streak,
-            categories,
-        });
-    }
+            categories: cats_map.remove(&user.id).unwrap_or_default(),
+        }
+    }).collect();
 
     entries.sort_by(|a, b| b.total_hours.partial_cmp(&a.total_hours).unwrap_or(std::cmp::Ordering::Equal));
 
     Ok(Json(entries))
 }
 
-async fn calculate_streak(pool: &SqlitePool, user_id: i64) -> i64 {
-    let dates: Vec<String> = sqlx::query_scalar(
-        "SELECT DISTINCT date FROM progress_logs WHERE user_id = ? ORDER BY date DESC LIMIT 365"
-    )
-    .bind(user_id)
-    .fetch_all(pool)
-    .await
-    .unwrap_or_default();
-
+fn calculate_streak_from_dates(dates: &[String], today: chrono::NaiveDate) -> i64 {
     if dates.is_empty() {
         return 0;
     }
-
-    let today = chrono::Local::now().date_naive();
     let mut streak = 0i64;
     let mut expected = today;
-
-    for date_str in &dates {
+    for date_str in dates {
         if let Ok(date) = chrono::NaiveDate::parse_from_str(date_str, "%Y-%m-%d") {
             if date == expected {
                 streak += 1;
@@ -110,6 +127,5 @@ async fn calculate_streak(pool: &SqlitePool, user_id: i64) -> i64 {
             }
         }
     }
-
     streak
 }

--- a/backend/src/routes/progressions.rs
+++ b/backend/src/routes/progressions.rs
@@ -44,6 +44,9 @@ pub async fn create_progression(
     AuthUser(user_id): AuthUser,
     Json(input): Json<ProgressionInput>,
 ) -> Result<Json<ProgressionWithPhases>, (StatusCode, String)> {
+    let mut tx = pool.begin().await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
     let prog = sqlx::query_as::<_, Progression>(
         "INSERT INTO progressions (user_id, name, label, emoji, color, current_level) VALUES (?, ?, ?, ?, ?, ?) RETURNING *"
     )
@@ -53,7 +56,7 @@ pub async fn create_progression(
     .bind(&input.emoji)
     .bind(&input.color)
     .bind(&input.current_level)
-    .fetch_one(&pool)
+    .fetch_one(&mut *tx)
     .await
     .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
@@ -71,11 +74,14 @@ pub async fn create_progression(
         .bind(phase.resources.as_ref().map(|r| serde_json::to_string(r).unwrap_or_default()))
         .bind(&phase.milestone)
         .bind(i as i64)
-        .fetch_one(&pool)
+        .fetch_one(&mut *tx)
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
         phases.push(p);
     }
+
+    tx.commit().await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
     Ok(Json(ProgressionWithPhases { progression: prog, phases }))
 }
@@ -92,14 +98,17 @@ pub async fn update_progression(
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
         .ok_or((StatusCode::NOT_FOUND, "Progression not found".into()))?;
 
+    let mut tx = pool.begin().await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
     sqlx::query("UPDATE progressions SET name = ?, label = ?, emoji = ?, color = ?, current_level = ? WHERE id = ?")
         .bind(&input.name).bind(&input.label).bind(&input.emoji).bind(&input.color).bind(&input.current_level)
         .bind(existing.id)
-        .execute(&pool).await
+        .execute(&mut *tx).await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
     sqlx::query("DELETE FROM progression_phases WHERE progression_id = ?")
-        .bind(existing.id).execute(&pool).await
+        .bind(existing.id).execute(&mut *tx).await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
     let mut phases = Vec::new();
@@ -114,10 +123,13 @@ pub async fn update_progression(
         .bind(phase.resources.as_ref().map(|r| serde_json::to_string(r).unwrap_or_default()))
         .bind(&phase.milestone)
         .bind(i as i64)
-        .fetch_one(&pool).await
+        .fetch_one(&mut *tx).await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
         phases.push(p);
     }
+
+    tx.commit().await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
     let prog = sqlx::query_as::<_, Progression>("SELECT * FROM progressions WHERE id = ?")
         .bind(existing.id).fetch_one(&pool).await

--- a/backend/src/routes/schedules.rs
+++ b/backend/src/routes/schedules.rs
@@ -24,10 +24,18 @@ pub async fn put_schedule_day(
     AuthUser(user_id): AuthUser,
     Json(input): Json<BulkScheduleInput>,
 ) -> Result<Json<Vec<ScheduleBlock>>, (StatusCode, String)> {
+    // Validate time ranges
+    for block in &input.blocks {
+        validate_time_range(&block.time_range)?;
+    }
+
+    let mut tx = pool.begin().await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
+
     sqlx::query("DELETE FROM schedule_blocks WHERE user_id = ? AND day_of_week = ?")
         .bind(user_id)
         .bind(input.day_of_week)
-        .execute(&pool)
+        .execute(&mut *tx)
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
@@ -42,10 +50,13 @@ pub async fn put_schedule_day(
         .bind(&block.category_name)
         .bind(&block.note)
         .bind(block.sort_order.unwrap_or(i as i64))
-        .execute(&pool)
+        .execute(&mut *tx)
         .await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
     }
+
+    tx.commit().await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
     let blocks = sqlx::query_as::<_, ScheduleBlock>(
         "SELECT * FROM schedule_blocks WHERE user_id = ? AND day_of_week = ? ORDER BY sort_order"
@@ -57,6 +68,25 @@ pub async fn put_schedule_day(
     .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?;
 
     Ok(Json(blocks))
+}
+
+fn validate_time_range(time_range: &str) -> Result<(), (StatusCode, String)> {
+    // Allow single time (e.g. "22:00" for sleep) or range "HH:MM–HH:MM"
+    let parts: Vec<&str> = time_range.split(|c| c == '\u{2013}' || c == '-').collect();
+    for part in &parts {
+        let trimmed = part.trim();
+        if trimmed.is_empty() { continue; }
+        let time_parts: Vec<&str> = trimmed.split(':').collect();
+        if time_parts.len() != 2 {
+            return Err((StatusCode::BAD_REQUEST, format!("Invalid time format: '{}'. Use HH:MM", trimmed)));
+        }
+        let h: u32 = time_parts[0].parse().map_err(|_| (StatusCode::BAD_REQUEST, format!("Invalid hour in '{}'", trimmed)))?;
+        let m: u32 = time_parts[1].parse().map_err(|_| (StatusCode::BAD_REQUEST, format!("Invalid minute in '{}'", trimmed)))?;
+        if h > 23 || m > 59 {
+            return Err((StatusCode::BAD_REQUEST, format!("Time out of range: '{}'", trimmed)));
+        }
+    }
+    Ok(())
 }
 
 pub async fn get_user_schedules(

--- a/backend/src/session.rs
+++ b/backend/src/session.rs
@@ -25,6 +25,13 @@ pub async fn create_session(pool: &SqlitePool, user_id: i64) -> Result<String, s
 }
 
 pub async fn get_user_id_from_token(pool: &SqlitePool, token: &str) -> Option<i64> {
+    // Opportunistically clean expired sessions (~1% of requests)
+    let r: u8 = rand::thread_rng().r#gen();
+    if r < 3 {
+        sqlx::query("DELETE FROM sessions WHERE expires_at < datetime('now')")
+            .execute(pool).await.ok();
+    }
+
     sqlx::query_scalar::<_, i64>(
         "SELECT user_id FROM sessions WHERE token = ? AND expires_at > datetime('now')"
     )


### PR DESCRIPTION
## Summary

- **Database indexes** — Added migration `002_indexes.sql` with 11 indexes on foreign keys and hot query paths. Most impactful: `idx_sessions_token`, `idx_progress_logs_user_date`, `idx_schedule_blocks_user_day`.
- **N+1 fix in leaderboard** — Previously ran 2N+1 queries (one per friend for user data, totals, categories, streaks). Now batches everything into 5 queries regardless of friend count.
- **Transactions** — Schedule put, budget set, and progression create/update all wrapped in `BEGIN..COMMIT` so partial failures roll back cleanly instead of leaving orphaned data.
- **Session cleanup** — Expired sessions deleted on startup + probabilistic cleanup (~1% of auth checks) to prevent table bloat.
- **Time range validation** — Server now rejects invalid time formats (e.g. `25:00`, `abc`) with 400 Bad Request.

## Test plan

- [ ] Create/update a schedule → verify blocks save correctly
- [ ] Create a progression with phases → verify all phases save atomically
- [ ] Set a budget → verify items persist
- [ ] Check leaderboard with friends → should load fast, show correct data
- [ ] Submit invalid time like `25:00–30:00` → should get 400 error

Closes #4, Closes #5, Closes #8, Closes #9, Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)