### PR TITLE
Add inline quick-add for schedule blocks

### DIFF
--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -161,7 +161,7 @@ export default function Dashboard() {
       setSchedules(fresh);
       setQuickAdd({ time_range: "", label: "", category_name: categories.length > 0 ? categories[0].name : "", note: "" });
       setShowQuickAdd(false);
-    } catch (e) { setError(e.message); }
+    } catch (e) { alert(e.message); }
   };
 
   // ── Category CRUD ──


### PR DESCRIPTION
## Summary
- **Add "+ Add Block" button** below the schedule view (dashed border, always visible when not in edit mode)
- **Inline form** expands in-place with time range input, activity name, and category dropdown
- **Enter key support** — press Enter in the activity name field to submit
- **Appends to existing schedule** — no need to enter full edit mode just to add one block
- **Empty day state** now includes a quick-add link alongside the existing instructions

## Issues
Closes #1 — Improve schedule event creation UX - add inline quick-add

## Before
Users had to click "Edit Day" → "Add Block" → fill in fields → click "Save" (4 steps, enters edit mode for the whole day)

## After
Users click "+ Add Block" → fill in time + name + category → click "Add" (2 steps, stays in view mode)

Full edit mode ("Edit Day") still available for reordering, bulk editing, and deleting blocks.

## Test plan
- [ ] Click "+ Add Block" on a day with existing schedule → inline form appears
- [ ] Fill in time range + activity name + select category → click Add → block appears in schedule
- [ ] Press Enter in activity name field → block is added
- [ ] Click X to dismiss the quick-add form
- [ ] On empty day, click the "+ Add Block" link in the placeholder → form appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)