### PR TITLE
Add CI/CD pipeline with GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  build:
+    name: Build & Validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Rust dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            backend/target
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: rust-${{ hashFiles('backend/Cargo.lock', 'backend/Cargo.toml') }}
+          restore-keys: rust-
+
+      - name: Build backend
+        working-directory: backend
+        run: cargo build --release
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Cache node_modules
+        uses: actions/cache@v4
+        with:
+          path: frontend/node_modules
+          key: node-${{ hashFiles('frontend/package.json') }}
+          restore-keys: node-
+
+      - name: Build frontend
+        working-directory: frontend
+        run: |
+          npm install
+          npm run build
+
+      - name: Check for warnings
+        working-directory: backend
+        run: cargo build --release 2>&1 | grep -i warning || echo "No warnings"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,26 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch: # allow manual trigger from GitHub UI
+
+jobs:
+  deploy:
+    name: Build & Deploy
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build frontend
+        working-directory: frontend
+        run: |
+          npm install
+          npm run build
+
+      - name: Build backend
+        working-directory: backend
+        run: cargo build --release
+
+      - name: Deploy
+        run: ./scripts/deploy.sh

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ Thumbs.db
 
 # Env
 .env
+
+# GitHub Actions self-hosted runner
+.github-runner/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build build-backend build-frontend dev dev-backend dev-frontend run stop clean service-install service-start service-stop service-logs
+.PHONY: build build-backend build-frontend dev dev-backend dev-frontend run stop clean deploy setup-runner service-install service-start service-stop service-logs
 
 # ── Production ──────────────────────────────────────────────
 
@@ -31,6 +31,14 @@ dev-backend:
 
 dev-frontend:
 	cd frontend && npm run dev
+
+# ── Deploy ──────────────────────────────────────────────────
+
+deploy: build
+	@./scripts/deploy.sh
+
+setup-runner:
+	@./scripts/setup-runner.sh
 
 # ── Utilities ───────────────────────────────────────────────
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Deploy script — stops the running server, swaps the binary, restarts.
+# Called by GitHub Actions deploy workflow on the self-hosted runner.
+set -e
+
+PROJECT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+PID_FILE="$PROJECT_DIR/.server.pid"
+BINARY="$PROJECT_DIR/backend/target/release/the-plan-backend"
+FRONTEND="$PROJECT_DIR/frontend/dist"
+LOG_DIR="$PROJECT_DIR/logs"
+
+echo "=== Deploying The Plan ==="
+echo "Project: $PROJECT_DIR"
+echo "Time:    $(date)"
+
+# 1. Stop current server
+if [ -f "$PID_FILE" ]; then
+  PID=$(cat "$PID_FILE")
+  if kill -0 "$PID" 2>/dev/null; then
+    echo "Stopping server (PID $PID)..."
+    kill "$PID"
+    # Wait for graceful shutdown (up to 10s)
+    for i in $(seq 1 10); do
+      kill -0 "$PID" 2>/dev/null || break
+      sleep 1
+    done
+    # Force kill if still alive
+    kill -0 "$PID" 2>/dev/null && kill -9 "$PID" 2>/dev/null
+    echo "Server stopped."
+  else
+    echo "Stale PID file, cleaning up."
+  fi
+  rm -f "$PID_FILE"
+else
+  # Try to find and kill any running instance
+  pkill -f the-plan-backend 2>/dev/null && echo "Stopped orphan process." || true
+  sleep 1
+fi
+
+# 2. Verify binary exists
+if [ ! -f "$BINARY" ]; then
+  echo "ERROR: Binary not found at $BINARY"
+  exit 1
+fi
+
+if [ ! -d "$FRONTEND" ]; then
+  echo "ERROR: Frontend dist not found at $FRONTEND"
+  exit 1
+fi
+
+# 3. Start new server
+mkdir -p "$LOG_DIR" "$PROJECT_DIR/data"
+
+echo "Starting server..."
+DATABASE_PATH="$PROJECT_DIR/data/theplan.db" \
+  FRONTEND_DIR="$FRONTEND" \
+  PORT=3000 \
+  nohup "$BINARY" >> "$LOG_DIR/server.log" 2>&1 &
+
+echo $! > "$PID_FILE"
+sleep 2
+
+# 4. Health check
+if kill -0 "$(cat "$PID_FILE")" 2>/dev/null; then
+  echo "=== Deploy successful ==="
+  echo "PID: $(cat "$PID_FILE")"
+  echo "URL: http://localhost:3000"
+
+  # Try to get Tailscale IP
+  if command -v tailscale &>/dev/null; then
+    TS_IP=$(tailscale ip -4 2>/dev/null || true)
+    [ -n "$TS_IP" ] && echo "Tailscale: http://${TS_IP}:3000"
+  fi
+else
+  echo "=== Deploy FAILED ==="
+  echo "Server did not start. Last 20 lines of log:"
+  tail -20 "$LOG_DIR/server.log" 2>/dev/null || true
+  rm -f "$PID_FILE"
+  exit 1
+fi

--- a/scripts/setup-runner.sh
+++ b/scripts/setup-runner.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+# Sets up a GitHub Actions self-hosted runner on your Mac Mini.
+# Run this once on your Mac Mini to enable automatic deployments.
+#
+# Prerequisites:
+#   - Rust installed (curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh)
+#   - Node.js installed (brew install node)
+#   - GitHub CLI authenticated (gh auth login)
+#
+# Usage: ./scripts/setup-runner.sh
+
+set -e
+
+PROJECT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+RUNNER_DIR="$PROJECT_DIR/.github-runner"
+
+echo "=== GitHub Actions Self-Hosted Runner Setup ==="
+echo ""
+
+# Check prerequisites
+echo "Checking prerequisites..."
+command -v cargo >/dev/null 2>&1 || { echo "ERROR: Rust not installed. Run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh"; exit 1; }
+command -v node >/dev/null 2>&1 || { echo "ERROR: Node.js not installed. Run: brew install node"; exit 1; }
+command -v gh >/dev/null 2>&1 || { echo "ERROR: GitHub CLI not installed. Run: brew install gh"; exit 1; }
+echo "All prerequisites found."
+echo ""
+
+# Get runner token from GitHub
+echo "Getting runner registration token..."
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null)
+if [ -z "$REPO" ]; then
+  echo "ERROR: Could not determine repo. Make sure you're in the project directory and gh is authenticated."
+  exit 1
+fi
+echo "Repository: $REPO"
+
+TOKEN=$(gh api "repos/${REPO}/actions/runners/registration-token" --method POST -q .token 2>/dev/null)
+if [ -z "$TOKEN" ]; then
+  echo "ERROR: Could not get runner token. Make sure you have admin access to the repo."
+  exit 1
+fi
+
+# Determine architecture
+ARCH=$(uname -m)
+case "$ARCH" in
+  arm64) RUNNER_ARCH="osx-arm64" ;;
+  x86_64) RUNNER_ARCH="osx-x64" ;;
+  *) echo "ERROR: Unsupported architecture: $ARCH"; exit 1 ;;
+esac
+
+OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+RUNNER_VERSION="2.322.0"
+
+echo ""
+echo "Platform: ${OS}-${ARCH} (runner: ${RUNNER_ARCH})"
+echo ""
+
+# Download and extract runner
+mkdir -p "$RUNNER_DIR"
+cd "$RUNNER_DIR"
+
+if [ ! -f "./config.sh" ]; then
+  RUNNER_TAR="actions-runner-${RUNNER_ARCH}-${RUNNER_VERSION}.tar.gz"
+  RUNNER_URL="https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/${RUNNER_TAR}"
+
+  echo "Downloading runner v${RUNNER_VERSION}..."
+  curl -sL "$RUNNER_URL" -o "$RUNNER_TAR"
+  echo "Extracting..."
+  tar xzf "$RUNNER_TAR"
+  rm -f "$RUNNER_TAR"
+fi
+
+# Configure runner
+echo ""
+echo "Configuring runner..."
+./config.sh \
+  --url "https://github.com/${REPO}" \
+  --token "$TOKEN" \
+  --name "mac-mini" \
+  --labels "self-hosted,macOS,ARM64" \
+  --work "_work" \
+  --replace
+
+# Install as a service (runs in background, survives reboots)
+echo ""
+echo "Installing runner as a service..."
+./svc.sh install
+./svc.sh start
+
+echo ""
+echo "=== Setup Complete ==="
+echo ""
+echo "The runner is now active and will pick up deploy jobs."
+echo "You can check its status at:"
+echo "  https://github.com/${REPO}/settings/actions/runners"
+echo ""
+echo "Runner commands:"
+echo "  Start:   cd $RUNNER_DIR && ./svc.sh start"
+echo "  Stop:    cd $RUNNER_DIR && ./svc.sh stop"
+echo "  Status:  cd $RUNNER_DIR && ./svc.sh status"
+echo ""
+echo "=== How deployment works ==="
+echo "1. Create a PR on GitHub"
+echo "2. CI runs automatically to validate the build"
+echo "3. Merge the PR to main"
+echo "4. Deploy workflow runs on this Mac Mini"
+echo "5. App is rebuilt and restarted automatically"


### PR DESCRIPTION
## Summary
Adds a full CI/CD pipeline so merging a PR automatically builds and deploys to the Mac Mini.

## How it works

```
PR opened → CI validates build → you merge → Deploy runs on Mac Mini → app restarts
```

### CI (`ci.yml`) — runs on every PR
- Builds backend (`cargo build --release`) on GitHub-hosted Linux
- Builds frontend (`npm install && npm run build`)
- Caches Rust + Node dependencies for fast reruns
- Validates that code compiles before you merge

### Deploy (`deploy.yml`) — runs on push to main
- Triggers automatically when PRs are merged
- Can also be triggered manually from GitHub Actions UI
- Runs on a **self-hosted runner** on the Mac Mini
- Builds natively, stops old server, starts new one, health checks

## New files

| File | Purpose |
|------|---------|
| `.github/workflows/ci.yml` | PR validation workflow |
| `.github/workflows/deploy.yml` | Auto-deploy on merge |
| `scripts/deploy.sh` | Stop → build → start → health check |
| `scripts/setup-runner.sh` | One-time setup to install GitHub Actions runner on Mac Mini |
| `backend/Cargo.lock` | Reproducible Rust builds in CI |

## One-time setup on your Mac Mini

After merging this PR, run on the Mac Mini:

```bash
cd /path/to/the-plan
./scripts/setup-runner.sh
```

This installs a GitHub Actions runner as a background service. After that, the workflow is:

1. Create a PR (or push to a feature branch)
2. CI runs automatically — green check means it builds
3. Merge the PR
4. Deploy workflow picks it up, builds on the Mac Mini, restarts the server
5. App is live with the new changes

No more `ctrl+c → git pull → rebuild → run` manually.

## Test plan
- [ ] Open a test PR → verify CI workflow runs and passes
- [ ] Run `./scripts/setup-runner.sh` on Mac Mini → verify runner appears in repo settings
- [ ] Merge a PR → verify deploy workflow triggers and app restarts

🤖 Generated with [Claude Code](https://claude.com/claude-code)