### PR TITLE
Fix deploy: stable dir + detach from runner

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,16 +1,24 @@
 #!/bin/bash
-# Deploy script — stops the running server, swaps the binary, restarts.
+# Deploy script — copies built artifacts to deploy dir, restarts server.
 # Called by GitHub Actions deploy workflow on the self-hosted runner.
+#
+# The runner builds in its own work directory. This script copies the
+# binary + frontend dist to a fixed deploy location, then starts the
+# server fully detached so the runner cleanup doesn't kill it.
 set -e
 
-PROJECT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-PID_FILE="$PROJECT_DIR/.server.pid"
-BINARY="$PROJECT_DIR/backend/target/release/the-plan-backend"
-FRONTEND="$PROJECT_DIR/frontend/dist"
-LOG_DIR="$PROJECT_DIR/logs"
+# Where the runner built everything (current checkout)
+BUILD_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+# Fixed deploy location — outside the runner's work tree
+DEPLOY_DIR="${DEPLOY_DIR:-$HOME/the-plan-deploy}"
+PID_FILE="$DEPLOY_DIR/.server.pid"
+LOG_DIR="$DEPLOY_DIR/logs"
+DATA_DIR="$DEPLOY_DIR/data"
 
 echo "=== Deploying The Plan ==="
-echo "Project: $PROJECT_DIR"
+echo "Build:   $BUILD_DIR"
+echo "Deploy:  $DEPLOY_DIR"
 echo "Time:    $(date)"
 
 # 1. Stop current server
@@ -19,12 +27,10 @@ if [ -f "$PID_FILE" ]; then
   if kill -0 "$PID" 2>/dev/null; then
     echo "Stopping server (PID $PID)..."
     kill "$PID"
-    # Wait for graceful shutdown (up to 10s)
     for i in $(seq 1 10); do
       kill -0 "$PID" 2>/dev/null || break
       sleep 1
     done
-    # Force kill if still alive
     kill -0 "$PID" 2>/dev/null && kill -9 "$PID" 2>/dev/null
     echo "Server stopped."
   else
@@ -32,12 +38,14 @@ if [ -f "$PID_FILE" ]; then
   fi
   rm -f "$PID_FILE"
 else
-  # Try to find and kill any running instance
   pkill -f the-plan-backend 2>/dev/null && echo "Stopped orphan process." || true
   sleep 1
 fi
 
-# 2. Verify binary exists
+# 2. Verify build artifacts exist
+BINARY="$BUILD_DIR/backend/target/release/the-plan-backend"
+FRONTEND="$BUILD_DIR/frontend/dist"
+
 if [ ! -f "$BINARY" ]; then
   echo "ERROR: Binary not found at $BINARY"
   exit 1
@@ -48,25 +56,34 @@ if [ ! -d "$FRONTEND" ]; then
   exit 1
 fi
 
-# 3. Start new server
-mkdir -p "$LOG_DIR" "$PROJECT_DIR/data"
+# 3. Copy artifacts to deploy directory
+mkdir -p "$DEPLOY_DIR/bin" "$DEPLOY_DIR/frontend" "$LOG_DIR" "$DATA_DIR"
 
+echo "Copying binary..."
+cp "$BINARY" "$DEPLOY_DIR/bin/the-plan-backend"
+
+echo "Copying frontend..."
+rm -rf "$DEPLOY_DIR/frontend/dist"
+cp -r "$FRONTEND" "$DEPLOY_DIR/frontend/dist"
+
+# 4. Start server fully detached from runner process group
 echo "Starting server..."
-DATABASE_PATH="$PROJECT_DIR/data/theplan.db" \
-  FRONTEND_DIR="$FRONTEND" \
+setsid bash -c "
+  DATABASE_PATH='$DATA_DIR/theplan.db' \
+  FRONTEND_DIR='$DEPLOY_DIR/frontend/dist' \
   PORT=3000 \
-  nohup "$BINARY" >> "$LOG_DIR/server.log" 2>&1 &
+  nohup '$DEPLOY_DIR/bin/the-plan-backend' >> '$LOG_DIR/server.log' 2>&1 &
+  echo \$! > '$PID_FILE'
+"
 
-echo $! > "$PID_FILE"
 sleep 2
 
-# 4. Health check
-if kill -0 "$(cat "$PID_FILE")" 2>/dev/null; then
+# 5. Health check
+if [ -f "$PID_FILE" ] && kill -0 "$(cat "$PID_FILE")" 2>/dev/null; then
   echo "=== Deploy successful ==="
   echo "PID: $(cat "$PID_FILE")"
   echo "URL: http://localhost:3000"
 
-  # Try to get Tailscale IP
   if command -v tailscale &>/dev/null; then
     TS_IP=$(tailscale ip -4 2>/dev/null || true)
     [ -n "$TS_IP" ] && echo "Tailscale: http://${TS_IP}:3000"

--- a/scripts/theplan
+++ b/scripts/theplan
@@ -3,14 +3,30 @@
 # Usage: theplan [start|stop|status|logs|rebuild]
 
 PROJECT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
-PLIST_NAME="com.theplan.server"
-PLIST_PATH="$HOME/Library/LaunchAgents/${PLIST_NAME}.plist"
-PID_FILE="$PROJECT_DIR/.server.pid"
+DEPLOY_DIR="${DEPLOY_DIR:-$HOME/the-plan-deploy}"
+
+# Check both deploy dir (CI/CD) and project dir (manual) for PID
+if [ -f "$DEPLOY_DIR/.server.pid" ]; then
+  PID_FILE="$DEPLOY_DIR/.server.pid"
+  LOG_DIR="$DEPLOY_DIR/logs"
+elif [ -f "$PROJECT_DIR/.server.pid" ]; then
+  PID_FILE="$PROJECT_DIR/.server.pid"
+  LOG_DIR="$PROJECT_DIR/logs"
+else
+  PID_FILE="$PROJECT_DIR/.server.pid"
+  LOG_DIR="$PROJECT_DIR/logs"
+fi
 
 case "${1:-status}" in
   start)
     if [ -f "$PID_FILE" ] && kill -0 "$(cat "$PID_FILE")" 2>/dev/null; then
       echo "Already running (PID $(cat "$PID_FILE"))"
+      exit 0
+    fi
+
+    # Also check deploy dir PID
+    if [ -f "$DEPLOY_DIR/.server.pid" ] && kill -0 "$(cat "$DEPLOY_DIR/.server.pid")" 2>/dev/null; then
+      echo "Already running via deploy (PID $(cat "$DEPLOY_DIR/.server.pid"))"
       exit 0
     fi
 
@@ -20,9 +36,11 @@ case "${1:-status}" in
       cd "$PROJECT_DIR" && make build
     fi
 
-    mkdir -p "$PROJECT_DIR/logs" "$PROJECT_DIR/backend/data"
+    PID_FILE="$PROJECT_DIR/.server.pid"
+    LOG_DIR="$PROJECT_DIR/logs"
+    mkdir -p "$LOG_DIR" "$PROJECT_DIR/backend/data"
     FRONTEND_DIR="$PROJECT_DIR/frontend/dist" \
-      nohup "$BINARY" >> "$PROJECT_DIR/logs/server.log" 2>&1 &
+      nohup "$BINARY" >> "$LOG_DIR/server.log" 2>&1 &
     echo $! > "$PID_FILE"
 
     sleep 1
@@ -33,23 +51,35 @@ case "${1:-status}" in
       echo "  Network:   http://${IP:-your-ip}:3000"
       echo "  Tailscale: http://$(hostname):3000"
     else
-      echo "Failed to start. Check logs/server.log"
+      echo "Failed to start. Check $LOG_DIR/server.log"
       rm -f "$PID_FILE"
       exit 1
     fi
     ;;
 
   stop)
-    if [ -f "$PID_FILE" ]; then
-      PID=$(cat "$PID_FILE")
+    stopped=false
+    # Stop deploy instance
+    if [ -f "$DEPLOY_DIR/.server.pid" ]; then
+      PID=$(cat "$DEPLOY_DIR/.server.pid")
       if kill -0 "$PID" 2>/dev/null; then
         kill "$PID"
-        echo "Stopped (PID $PID)"
-      else
-        echo "Process not running (stale PID file)"
+        echo "Stopped deploy instance (PID $PID)"
+        stopped=true
       fi
-      rm -f "$PID_FILE"
-    else
+      rm -f "$DEPLOY_DIR/.server.pid"
+    fi
+    # Stop manual instance
+    if [ -f "$PROJECT_DIR/.server.pid" ]; then
+      PID=$(cat "$PROJECT_DIR/.server.pid")
+      if kill -0 "$PID" 2>/dev/null; then
+        kill "$PID"
+        echo "Stopped manual instance (PID $PID)"
+        stopped=true
+      fi
+      rm -f "$PROJECT_DIR/.server.pid"
+    fi
+    if ! $stopped; then
       pkill -f the-plan-backend 2>/dev/null && echo "Stopped" || echo "Not running"
     fi
     ;;
@@ -61,15 +91,21 @@ case "${1:-status}" in
     ;;
 
   status)
-    if [ -f "$PID_FILE" ] && kill -0 "$(cat "$PID_FILE")" 2>/dev/null; then
-      echo "Running (PID $(cat "$PID_FILE"))"
+    if [ -f "$DEPLOY_DIR/.server.pid" ] && kill -0 "$(cat "$DEPLOY_DIR/.server.pid")" 2>/dev/null; then
+      echo "Running via deploy (PID $(cat "$DEPLOY_DIR/.server.pid"))"
+    elif [ -f "$PROJECT_DIR/.server.pid" ] && kill -0 "$(cat "$PROJECT_DIR/.server.pid")" 2>/dev/null; then
+      echo "Running (PID $(cat "$PROJECT_DIR/.server.pid"))"
     else
       echo "Not running"
     fi
     ;;
 
   logs)
-    tail -f "$PROJECT_DIR/logs/server.log"
+    if [ -f "$DEPLOY_DIR/logs/server.log" ]; then
+      tail -f "$DEPLOY_DIR/logs/server.log"
+    else
+      tail -f "$PROJECT_DIR/logs/server.log"
+    fi
     ;;
 
   rebuild)


### PR DESCRIPTION
## Summary
- Deploy script now copies built binary + frontend to `~/the-plan-deploy` instead of running from the runner's ephemeral work directory
- Uses `setsid` to fully detach the server process so GitHub Actions runner cleanup doesn't kill it
- `scripts/theplan` CLI updated to check both deploy and manual PID files

## What was broken
The server started inside `~/.github-runner/_work/the-plan/the-plan` and was killed by the runner's post-job cleanup. The app appeared to deploy successfully but died seconds later.

## Test plan
- [ ] Merge this PR → deploy workflow runs → server stays alive after job completes
- [ ] `scripts/theplan status` shows running
- [ ] App accessible from another machine via Tailscale
- [ ] `scripts/theplan stop` still works
- [ ] Manual `scripts/theplan rebuild` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)