### PR TITLE
Disable runner orphan process cleanup so server survives deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   workflow_dispatch: # allow manual trigger from GitHub UI
 
+env:
+  RUNNER_TRACKING_ID: ""  # Prevent runner from killing processes started by deploy
+
 jobs:
   deploy:
     name: Build & Deploy


### PR DESCRIPTION
The GitHub Actions runner kills all processes spawned during a job in its post-job cleanup phase. Setting RUNNER_TRACKING_ID to empty disables this tracking so the server process stays alive after deploy.