### PR TITLE
Improve schedule editing UX: flexible time, auto-sort, drag-and-drop

### DIFF
--- a/frontend/src/components/TimeRangeInput.jsx
+++ b/frontend/src/components/TimeRangeInput.jsx
@@ -1,5 +1,6 @@
 import { useState, useRef } from "react";
 import { COLORS } from "../theme";
+import { parseFlexibleTime } from "../utils/timeParser";
 
 function formatTimeDigits(raw) {
   const digits = raw.replace(/\D/g, "");
@@ -11,19 +12,19 @@ function formatTimeDigits(raw) {
 export default function TimeRangeInput({ value, onChange, style = {} }) {
   const [startRaw, setStartRaw] = useState(() => {
     if (!value) return "";
-    const parts = value.split(/\s*[-–]\s*/);
+    const parts = value.split(/\s*[-\u2013]\s*/);
     return parts[0] || "";
   });
   const [endRaw, setEndRaw] = useState(() => {
     if (!value) return "";
-    const parts = value.split(/\s*[-–]\s*/);
+    const parts = value.split(/\s*[-\u2013]\s*/);
     return parts[1] || "";
   });
   const endRef = useRef(null);
 
   const emit = (s, e) => {
-    const start = formatTimeDigits(s);
-    const end = formatTimeDigits(e);
+    const start = parseFlexibleTime(s) || formatTimeDigits(s);
+    const end = parseFlexibleTime(e) || formatTimeDigits(e);
     if (start && end) {
       onChange(`${start}\u2013${end}`);
     } else if (start) {
@@ -34,24 +35,36 @@ export default function TimeRangeInput({ value, onChange, style = {} }) {
   };
 
   const handleStart = (e) => {
-    let raw = e.target.value.replace(/[^\d:]/g, "");
+    let raw = e.target.value.replace(/[^\d:apmAPM ]/g, "");
     const digits = raw.replace(/\D/g, "");
     if (digits.length > 4) return;
-    const formatted = formatTimeDigits(raw);
-    setStartRaw(formatted);
-    emit(formatted, endRaw);
-    if (digits.length >= 4 && endRef.current) {
+    setStartRaw(raw);
+    emit(raw, endRaw);
+    if (digits.length >= 4 && endRef.current && !/[apmAPM]/.test(raw)) {
       endRef.current.focus();
     }
   };
 
   const handleEnd = (e) => {
-    let raw = e.target.value.replace(/[^\d:]/g, "");
+    let raw = e.target.value.replace(/[^\d:apmAPM ]/g, "");
     const digits = raw.replace(/\D/g, "");
     if (digits.length > 4) return;
-    const formatted = formatTimeDigits(raw);
-    setEndRaw(formatted);
-    emit(startRaw, formatted);
+    setEndRaw(raw);
+    emit(startRaw, raw);
+  };
+
+  const handleBlur = (which) => {
+    const raw = which === "start" ? startRaw : endRaw;
+    const parsed = parseFlexibleTime(raw);
+    if (parsed) {
+      if (which === "start") {
+        setStartRaw(parsed);
+        emit(parsed, endRaw);
+      } else {
+        setEndRaw(parsed);
+        emit(startRaw, parsed);
+      }
+    }
   };
 
   const base = {
@@ -63,7 +76,7 @@ export default function TimeRangeInput({ value, onChange, style = {} }) {
     fontSize: 13,
     fontFamily: "'IBM Plex Mono', monospace",
     outline: "none",
-    width: 58,
+    width: 64,
     textAlign: "center",
     transition: "border-color 0.15s",
   };
@@ -74,10 +87,10 @@ export default function TimeRangeInput({ value, onChange, style = {} }) {
         style={base}
         value={startRaw}
         onChange={handleStart}
-        placeholder="06:00"
-        maxLength={5}
+        placeholder="6pm"
+        maxLength={7}
         onFocus={e => e.target.style.borderColor = COLORS.accent}
-        onBlur={e => e.target.style.borderColor = COLORS.border}
+        onBlur={e => { e.target.style.borderColor = COLORS.border; handleBlur("start"); }}
       />
       <span style={{ color: COLORS.textFaint, fontSize: 12, fontWeight: 600 }}>{"\u2013"}</span>
       <input
@@ -85,10 +98,10 @@ export default function TimeRangeInput({ value, onChange, style = {} }) {
         style={base}
         value={endRaw}
         onChange={handleEnd}
-        placeholder="07:30"
-        maxLength={5}
+        placeholder="7:30"
+        maxLength={7}
         onFocus={e => e.target.style.borderColor = COLORS.accent}
-        onBlur={e => e.target.style.borderColor = COLORS.border}
+        onBlur={e => { e.target.style.borderColor = COLORS.border; handleBlur("end"); }}
       />
     </div>
   );

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -9,6 +9,7 @@ import BudgetBar from "../components/BudgetBar";
 import TimeRangeInput from "../components/TimeRangeInput";
 import Modal from "../components/Modal";
 import ColorPicker from "../components/ColorPicker";
+import { sortBlocksByTime } from "../utils/timeParser";
 import * as api from "../api";
 import * as S from "../styles";
 
@@ -63,6 +64,8 @@ export default function Dashboard() {
   const [editBlocks, setEditBlocks] = useState([]);
   const [showQuickAdd, setShowQuickAdd] = useState(false);
   const [quickAdd, setQuickAdd] = useState({ time_range: "", label: "", category_name: "", note: "" });
+  const [dragIdx, setDragIdx] = useState(null);
+  const [dragOverIdx, setDragOverIdx] = useState(null);
 
   // Category form
   const [catName, setCatName] = useState("");
@@ -156,7 +159,8 @@ export default function Dashboard() {
   const saveSchedule = async () => {
     setSaving(true); setError("");
     try {
-      await api.schedules.putDay({ day_of_week: schedDay, blocks: editBlocks });
+      const sorted = sortBlocksByTime(editBlocks);
+      await api.schedules.putDay({ day_of_week: schedDay, blocks: sorted });
       const fresh = await api.schedules.list();
       setSchedules(fresh);
       setEditing(false);
@@ -167,6 +171,38 @@ export default function Dashboard() {
   const addBlock = () => {
     const defaultCat = categories.length > 0 ? categories[0].name : "prog";
     setEditBlocks([...editBlocks, { time_range: "", label: "", category_name: defaultCat, note: "" }]);
+  };
+
+  const sortBlocks = () => {
+    setEditBlocks(sortBlocksByTime(editBlocks));
+  };
+
+  const handleDragStart = (idx) => {
+    setDragIdx(idx);
+  };
+
+  const handleDragOver = (e, idx) => {
+    e.preventDefault();
+    setDragOverIdx(idx);
+  };
+
+  const handleDrop = (idx) => {
+    if (dragIdx === null || dragIdx === idx) {
+      setDragIdx(null);
+      setDragOverIdx(null);
+      return;
+    }
+    const copy = [...editBlocks];
+    const [moved] = copy.splice(dragIdx, 1);
+    copy.splice(idx, 0, moved);
+    setEditBlocks(copy);
+    setDragIdx(null);
+    setDragOverIdx(null);
+  };
+
+  const handleDragEnd = () => {
+    setDragIdx(null);
+    setDragOverIdx(null);
   };
 
   const updateBlock = (idx, field, value) => {
@@ -183,7 +219,7 @@ export default function Dashboard() {
       time_range: s.time_range, label: s.label,
       category_name: s.category_name, note: s.note || "",
     }));
-    const newBlocks = [...existing, { ...quickAdd, note: quickAdd.note || "" }];
+    const newBlocks = sortBlocksByTime([...existing, { ...quickAdd, note: quickAdd.note || "" }]);
     try {
       await api.schedules.putDay({ day_of_week: schedDay, blocks: newBlocks });
       const fresh = await api.schedules.list();
@@ -609,11 +645,29 @@ export default function Dashboard() {
               /* Schedule Editor */
               <div>
                 {editBlocks.map((block, idx) => (
-                  <div key={idx} className="schedule-editor-row" style={{
-                    display: "flex", gap: 8, marginBottom: 6, alignItems: "center",
-                    padding: "8px 12px", background: COLORS.surface, borderRadius: 8,
-                    border: `1px solid ${COLORS.border}`,
-                  }}>
+                  <div
+                    key={idx}
+                    className="schedule-editor-row"
+                    draggable
+                    onDragStart={() => handleDragStart(idx)}
+                    onDragOver={(e) => handleDragOver(e, idx)}
+                    onDrop={() => handleDrop(idx)}
+                    onDragEnd={handleDragEnd}
+                    style={{
+                      display: "flex", gap: 8, marginBottom: 6, alignItems: "center",
+                      padding: "8px 12px", background: COLORS.surface, borderRadius: 8,
+                      border: `1px solid ${dragOverIdx === idx ? COLORS.accent : COLORS.border}`,
+                      opacity: dragIdx === idx ? 0.5 : 1,
+                      transition: "border-color 0.15s, opacity 0.15s",
+                    }}
+                  >
+                    <span
+                      style={{
+                        cursor: "grab", color: COLORS.textFaint, fontSize: 14,
+                        padding: "4px 2px", userSelect: "none", flexShrink: 0,
+                      }}
+                      title="Drag to reorder"
+                    >{"\u2630"}</span>
                     <TimeRangeInput value={block.time_range} onChange={v => updateBlock(idx, "time_range", v)} />
                     <input style={{ ...S.input, flex: 1 }} placeholder="Activity name" value={block.label} onChange={e => updateBlock(idx, "label", e.target.value)} />
                     <select style={{ ...S.select, width: 140 }} value={block.category_name} onChange={e => updateBlock(idx, "category_name", e.target.value)}>
@@ -623,7 +677,10 @@ export default function Dashboard() {
                     <button onClick={() => removeBlock(idx)} style={{ ...S.btnDanger, padding: "6px 10px", fontSize: 13, background: "transparent" }}>{"\u2715"}</button>
                   </div>
                 ))}
-                <button onClick={addBlock} style={{ ...S.btnSecondary, marginTop: 8, width: "100%", textAlign: "center" }}>+ Add Block</button>
+                <div style={{ display: "flex", gap: 8, marginTop: 8 }}>
+                  <button onClick={addBlock} style={{ ...S.btnSecondary, flex: 1, textAlign: "center" }}>+ Add Block</button>
+                  <button onClick={sortBlocks} style={{ ...S.btnSecondary, textAlign: "center" }} title="Sort blocks by start time">{"\u2195"} Sort by Time</button>
+                </div>
               </div>
             )}
           </div>

--- a/frontend/src/utils/timeParser.js
+++ b/frontend/src/utils/timeParser.js
@@ -1,0 +1,72 @@
+/**
+ * Parse flexible time input into HH:MM 24h format.
+ * Accepts: "6", "12", "630", "1200", "6a", "6am", "12p", "12pm", "6:30", "6:30pm", etc.
+ */
+export function parseFlexibleTime(raw) {
+  if (!raw) return "";
+  const trimmed = raw.trim().toLowerCase();
+
+  // Detect am/pm suffix
+  let isPM = false;
+  let isAM = false;
+  let cleaned = trimmed;
+  if (/p\.?m?\.?$/.test(cleaned)) {
+    isPM = true;
+    cleaned = cleaned.replace(/\s*p\.?m?\.?$/, "");
+  } else if (/a\.?m?\.?$/.test(cleaned)) {
+    isAM = true;
+    cleaned = cleaned.replace(/\s*a\.?m?\.?$/, "");
+  }
+
+  // If it already has a colon, parse directly
+  if (cleaned.includes(":")) {
+    const [hStr, mStr] = cleaned.split(":");
+    let h = parseInt(hStr, 10);
+    const m = parseInt(mStr, 10) || 0;
+    if (isNaN(h)) return "";
+    if (isPM && h < 12) h += 12;
+    if (isAM && h === 12) h = 0;
+    if (h > 23 || m > 59) return "";
+    return `${h.toString().padStart(2, "0")}:${m.toString().padStart(2, "0")}`;
+  }
+
+  // Digits only
+  const digits = cleaned.replace(/\D/g, "");
+  if (digits.length === 0) return "";
+
+  let h, m;
+  if (digits.length <= 2) {
+    // "6" -> 06:00, "12" -> 12:00
+    h = parseInt(digits, 10);
+    m = 0;
+  } else if (digits.length === 3) {
+    // "630" -> 6:30
+    h = parseInt(digits[0], 10);
+    m = parseInt(digits.slice(1), 10);
+  } else {
+    // "0630" or "1200" -> 06:30, 12:00
+    h = parseInt(digits.slice(0, 2), 10);
+    m = parseInt(digits.slice(2, 4), 10);
+  }
+
+  if (isPM && h < 12) h += 12;
+  if (isAM && h === 12) h = 0;
+  if (h > 23 || m > 59) return "";
+
+  return `${h.toString().padStart(2, "0")}:${m.toString().padStart(2, "0")}`;
+}
+
+/** Parse the start time from a time_range string into minutes for sorting */
+export function parseStartMinutes(timeRange) {
+  if (!timeRange) return Infinity;
+  const start = timeRange.split(/\s*[-\u2013]\s*/)[0];
+  const parsed = parseFlexibleTime(start);
+  if (!parsed) return Infinity;
+  const [h, m] = parsed.split(":").map(Number);
+  return h * 60 + m;
+}
+
+/** Sort blocks by their start time */
+export function sortBlocksByTime(blocks) {
+  return [...blocks].sort((a, b) => parseStartMinutes(a.time_range) - parseStartMinutes(b.time_range));
+}


### PR DESCRIPTION
## Summary
- **Flexible time input**: Users can now type `6`, `12pm`, `630`, `1200`, `6:30am` etc. and the input auto-formats to `HH:MM` on blur. No more strict format requirements.
- **Auto-sort blocks**: Schedule blocks are automatically sorted by start time when saving. A manual "Sort by Time" button is also available in the editor.
- **Drag-and-drop reordering**: Schedule editor rows have a drag handle (☰) for visual reordering. Blocks highlight on drag-over for clear feedback.

## Changes
- `frontend/src/utils/timeParser.js` — New shared utility with `parseFlexibleTime()`, `parseStartMinutes()`, and `sortBlocksByTime()`
- `frontend/src/components/TimeRangeInput.jsx` — Uses flexible parser, allows am/pm input, auto-formats on blur
- `frontend/src/pages/Dashboard.jsx` — Auto-sorts on save, sorts quick-add insertions, adds drag-and-drop with visual feedback, adds "Sort by Time" button

Closes #35

## Test plan
- [ ] Enter various time formats (`6`, `12pm`, `630`, `1200`, `6:30am`) and verify they auto-format to `HH:MM`
- [ ] Add blocks out of order and verify they sort on save
- [ ] Use "Sort by Time" button and verify immediate reorder
- [ ] Drag blocks to reorder and verify the new order persists
- [ ] Quick-add a block and verify it appears in chronological position

🤖 Generated with [Claude Code](https://claude.com/claude-code)