### PR TITLE
Remove setSaving(true) from buildAutoScheduleBlocks

### DIFF
--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -364,7 +364,6 @@ export default function Dashboard() {
     const active = autoActivities.filter(a => a.enabled);
     if (active.length === 0) { setError("Select at least one activity"); return null; }
 
-    setSaving(true); setError("");
     const parseTime = (t) => { const [h, m] = t.split(":").map(Number); return h * 60 + (m || 0); };
     const formatTime = (mins) => { const h = Math.floor(mins / 60); const m = mins % 60; return `${h.toString().padStart(2, "0")}:${m.toString().padStart(2, "0")}`; };
 


### PR DESCRIPTION
buildAutoScheduleBlocks is a synchronous data-building function called by previewAutoSchedule. It was setting saving=true but never resetting it, causing the "Apply Schedule" button to permanently show "Applying..." and become disabled after preview. The saving state is now only managed in applyAutoSchedule where the actual async API calls happen.